### PR TITLE
Add example to `set_default_color_continuous` and bugfixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GiottoVisuals
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R: c(
 	person("Ruben", "Dries", email = "rubendries@gmail.com",
 		 role = c("aut", "cre")),

--- a/R/aux_defaults.R
+++ b/R/aux_defaults.R
@@ -243,6 +243,49 @@ set_default_color_discrete_heatmap_clus = function(
 #' @param type_default data type specific default to use
 #' @param type whether setting is for ggplot2 'fill' or 'color' type function
 #' @param \dots additional params to pass to respective ggplot fill_gradient functions
+#' @examples
+#' \dontrun{
+#' library(GiottoVisuals)
+#'
+#' g = GiottoData::loadGiottoMini('vizgen')
+#'
+#' nr_feat_polys = function(...) {
+#'   spatInSituPlotPoints(g,
+#'                        polygon_fill = 'nr_feats',
+#'                        polygon_fill_as_factor = F,
+#'                        polygon_feat_type = 'aggregate',
+#'                        polygon_line_size = 0.1,
+#'                        polygon_alpha = 1,
+#'                        ...)
+#' }
+#'
+#' # default
+#' nr_feat_polys()
+#'
+#' # set global option level: viridis
+#' options('giotto.color_c_pal' = 'v')
+#' nr_feat_polys()
+#'
+#' # set instructions level: magma
+#' instructions(g, 'poly_color_c_pal') = 'magma'
+#' nr_feat_polys()
+#'
+#' instructions(g, 'poly_color_c_rev') = TRUE
+#' nr_feat_polys()
+#' nr_feat_polys(polygon_fill_gradient_style = 's')
+#'
+#'
+#' # set function level: miami
+#' instructions(g, 'poly_color_c_rev') = FALSE
+#' nr_feat_polys(polygon_fill_gradient = 'miami')
+#'
+#' # set function level: color vector (2 to n colors)
+#' nr_feat_polys(polygon_fill_gradient = c('green', 'purple'), polygon_fill_gradient_style = 's')
+#'
+#' nr_feat_polys(polygon_fill_gradient = c('blue', 'yellow', 'red'), polygon_fill_gradient_style = 's')
+#'
+#' nr_feat_polys(polygon_fill_gradient = c('darkgrey', 'darkblue', 'purple', 'violet', 'cyan'), polygon_fill_gradient_style = 's')
+#' }
 NULL
 
 

--- a/R/color_palettes.R
+++ b/R/color_palettes.R
@@ -436,7 +436,13 @@ pal_names = list(
     'youngturqs'
   ),
   rcartocolor = c(
-    rcartocolor::metacartocolors$Name
+    "ag_GrnYl",   "ag_Sunset",  "ArmyRose",   "Earth",      "Fall",
+    "Geyser",     "TealRose",   "Temps",      "Tropic",     "Antique",
+    "Bold",       "Pastel",     "Prism",      "Safe",       "Vivid",
+    "BluGrn",     "BluYl",      "BrwnYl",     "Burg",       "BurgYl",
+    "DarkMint",   "Emrld",      "Magenta",    "Mint",       "OrYel",
+    "Peach",      "PinkYl",     "Purp",       "PurpOr",     "RedOr",
+    "Sunset",     "SunsetDark", "Teal",       "TealGrn"
   )
 )
 

--- a/R/vis_spatial_in_situ.R
+++ b/R/vis_spatial_in_situ.R
@@ -86,7 +86,7 @@ spatInSituPlotPoints <- function(gobject,
                                  polygon_fill_as_factor = NULL,
                                  polygon_fill_code = NULL,
                                  polygon_alpha = 0.5,
-                                 polygon_line_size = 2,
+                                 polygon_line_size = 0.4,
                                  axis_text = 8,
                                  axis_title = 8,
                                  legend_text = 6,
@@ -546,7 +546,7 @@ spatInSituPlotHex = function(gobject,
   if (GiottoUtils::is_present(polygon_size)) {
     deprecate_warn('0.0.0.9000',
                    'GiottoVisuals::spatInSituPlotHex(polygon_size = )',
-                   'GiottoVisuals::spatInSituPlotHex(polygon_size = )')
+                   'GiottoVisuals::spatInSituPlotHex(polygon_line_size = )')
     polygon_line_size <- polygon_size
   }
 
@@ -791,7 +791,7 @@ spatInSituPlotDensity = function(gobject,
   if (GiottoUtils::is_present(polygon_size)) {
     deprecate_warn('0.0.0.9000',
                    'GiottoVisuals::spatInSituPlotDensity(polygon_size = )',
-                   'GiottoVisuals::spatInSituPlotDensity(polygon_size = )')
+                   'GiottoVisuals::spatInSituPlotDensity(polygon_line_size = )')
     polygon_line_size <- polygon_size
   }
 
@@ -825,7 +825,7 @@ spatInSituPlotDensity = function(gobject,
                                       polygon_fill = polygon_fill,
                                       polygon_fill_as_factor = polygon_fill_as_factor,
                                       polygon_alpha = polygon_alpha,
-                                      polygon_size = polygon_size,
+                                      polygon_size = polygon_line_size,
                                       coord_fix_ratio = coord_fix_ratio,
                                       axis_text = axis_text,
                                       axis_title = axis_title,

--- a/man/set_default_color_continuous.Rd
+++ b/man/set_default_color_continuous.Rd
@@ -112,3 +112,47 @@ be minimal. Specific wrapper functions should be used for each item that needs
 defaults setting (plots or types of features).
 
 }}
+\examples{
+\dontrun{
+library(GiottoVisuals)
+
+g = GiottoData::loadGiottoMini('vizgen')
+
+nr_feat_polys = function(...) {
+  spatInSituPlotPoints(g,
+                       polygon_fill = 'nr_feats',
+                       polygon_fill_as_factor = F,
+                       polygon_feat_type = 'aggregate',
+                       polygon_line_size = 0.1,
+                       polygon_alpha = 1,
+                       ...)
+}
+
+# default
+nr_feat_polys()
+
+# set global option level: viridis
+options('giotto.color_c_pal' = 'v')
+nr_feat_polys()
+
+# set instructions level: magma
+instructions(g, 'poly_color_c_pal') = 'magma'
+nr_feat_polys()
+
+instructions(g, 'poly_color_c_rev') = TRUE
+nr_feat_polys()
+nr_feat_polys(polygon_fill_gradient_style = 's')
+
+
+# set function level: miami
+instructions(g, 'poly_color_c_rev') = FALSE
+nr_feat_polys(polygon_fill_gradient = 'miami')
+
+# set function level: color vector (2 to n colors)
+nr_feat_polys(polygon_fill_gradient = c('green', 'purple'), polygon_fill_gradient_style = 's')
+
+nr_feat_polys(polygon_fill_gradient = c('blue', 'yellow', 'red'), polygon_fill_gradient_style = 's')
+
+nr_feat_polys(polygon_fill_gradient = c('darkgrey', 'darkblue', 'purple', 'violet', 'cyan'), polygon_fill_gradient_style = 's')
+}
+}

--- a/man/spatInSituPlotPoints.Rd
+++ b/man/spatInSituPlotPoints.Rd
@@ -35,7 +35,7 @@ spatInSituPlotPoints(
   polygon_fill_as_factor = NULL,
   polygon_fill_code = NULL,
   polygon_alpha = 0.5,
-  polygon_line_size = 2,
+  polygon_line_size = 0.4,
   axis_text = 8,
   axis_title = 8,
   legend_text = 6,


### PR DESCRIPTION
- Bump ver num
- Add example to `set_default_color_continuous`
- Fix deprecated param in `vis_spatial_in_situ.R`
- fix code that needed rcartocolor on load