### PR TITLE
update: `sankeyPlot()` to allow use of data.frame input

### DIFF
--- a/R/plot_sankey.R
+++ b/R/plot_sankey.R
@@ -437,6 +437,8 @@ sankey_relation_pair = function(g, gsp, rel_idx, node_idx_start = 0) {
 
 
 
+# sankeyPlot methods ####
+
 
 #' @title Create a sankey plot
 #' @name sankeyPlot
@@ -495,18 +497,18 @@ setMethod(
            ...) {
     GiottoUtils::package_check("networkD3")
     meta_type = match.arg(meta_type, choices = c('cell', 'feat'))
-    x@data_type = meta_type
+    y@data_type = meta_type
 
     # iterate through sankey relations in the giottoSankeyPlan
     node_idx_start = 0
     links_dt = data.table::data.table()
     nodes = c()
 
-    for (rel_i in seq(nrow(sankeyRelate(x)))) {
+    for (rel_i in seq(nrow(sankeyRelate(y)))) {
 
       rel_data = sankey_relation_pair(
-        g = gobject,
-        gsp = x,
+        g = x,
+        gsp = y,
         rel_idx = rel_i,
         node_idx_start = node_idx_start
       )
@@ -571,7 +573,7 @@ setMethod(
     # Defaults for spat_unit and feat_type are set inside of the getter if they
     # are provided as NULL
     meta_cm = meta_get_fun(
-      gobject = g,
+      gobject = x,
       spat_unit = spat_unit,
       feat_type = feat_type,
       output = 'cellMetaObj',
@@ -585,7 +587,7 @@ setMethod(
     if (!is.null(idx)) {
       meta_cm = meta_cm[idx]
     }
-    test_dt = meta_cm[][, x, with = FALSE]
+    test_dt = meta_cm[][, y, with = FALSE]
 
     res = sankey_compare(data_dt = test_dt)
     links_dt = res$links

--- a/man/sankeyPlot.Rd
+++ b/man/sankeyPlot.Rd
@@ -3,24 +3,28 @@
 \name{sankeyPlot}
 \alias{sankeyPlot}
 \alias{sankeyPlot,giotto,character-method}
+\alias{sankeyPlot,data.frame,missing-method}
 \title{Create a sankey plot}
 \usage{
-\S4method{sankeyPlot}{giotto,giottoSankeyPlan}(gobject, x, meta_type = c("cell", "feat"), ...)
+\S4method{sankeyPlot}{giotto,giottoSankeyPlan}(x, y, meta_type = c("cell", "feat"), ...)
 
 \S4method{sankeyPlot}{giotto,character}(
-  gobject,
   x,
+  y,
   spat_unit = NULL,
   feat_type = NULL,
   meta_type = c("cell", "feat"),
   idx = NULL,
   ...
 )
+
+\S4method{sankeyPlot}{data.frame,missing}(x, y, ...)
 }
 \arguments{
-\item{gobject}{giotto object}
+\item{x}{data source (gobject or data.frame-like object with relations
+between the first two cols provided)}
 
-\item{x}{giottoSankeyPlan object or character vector referring to source and
+\item{y}{giottoSankeyPlan object or character vector referring to source and
 target columns in metadata}
 
 \item{meta_type}{whether to use 'cell' (cell) or 'feat' (feature) metadata}
@@ -71,6 +75,9 @@ type sankeys can be set up using the \code{sankey_plan} param which accepts a
 }
 \examples{
 \dontrun{
+x = data.table::data.table(col1 = c('a', 'a', 'b'),
+                           col2 = c('x', 'y', 'y'))
+sankeyPlot(x)
 g = GiottoData::loadGiottoMini("vizgen")
 # with giottoSankeyPlan
 leiden = sankeySet(spat_unit = 'aggregate',


### PR DESCRIPTION
- param reorganization
- allow sankey plotting directly from a data.frame of relationships. Takes the first two columns of information.