### PR TITLE
Update gg images

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 
 ## enhancements
 - `giottoLargeImage` `max_window` and `colors` slot info is now followed during ggplot plotting
+- `giottoAffineImage` compatibility for giotto ggplot2 plotting functions
 
 ## new
 - `geom_text_repel()` and `geom_label_repel()` from `ggplot2` are now re-exported

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 ## enhancements
 - `giottoLargeImage` `max_window` and `colors` slot info is now followed during ggplot plotting
 
+## new
+- `geom_text_repel()` and `geom_label_repel()` from `ggplot2` are now re-exported
+
 # GiottoVisuals 0.2.3 (2024/05/28)
 
 ## bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # GiottoVisuals 0.2.4 
 
+## enhancements
+- `giottoLargeImage` `max_window` and `colors` slot info is now followed during ggplot plotting
 
 # GiottoVisuals 0.2.3 (2024/05/28)
 

--- a/man/auto_image_resample.Rd
+++ b/man/auto_image_resample.Rd
@@ -9,6 +9,8 @@
   img,
   plot_ext = NULL,
   img_border = 0.125,
+  crop_ratio_fun = .img_to_crop_ratio_gimage,
+  sample_fun = .sample_gimage,
   flex_resample = TRUE,
   max_sample = getOption("giotto.plot_img_max_sample", 5e+05),
   max_crop = getOption("giotto.plot_img_max_crop", 1e+08),
@@ -18,7 +20,7 @@
 \arguments{
 \item{img}{giotto image to plot}
 
-\item{plot_ext}{extent of plot (required)}
+\item{plot_ext}{extent of plot (defaults to the image extent)}
 
 \item{img_border}{if not 0 or FALSE, expand plot_ext by this percentage on
 each side before applying crop on image. See details}

--- a/man/gg_annotation_raster.Rd
+++ b/man/gg_annotation_raster.Rd
@@ -5,6 +5,7 @@
 \alias{gg_annotation_raster,gg,list-method}
 \alias{gg_annotation_raster,gg,giottoImage-method}
 \alias{gg_annotation_raster,gg,giottoLargeImage-method}
+\alias{gg_annotation_raster,gg,giottoAffineImage-method}
 \title{Append image to ggplot as annotation_raster}
 \usage{
 \S4method{gg_annotation_raster}{gg,list}(ggobj, gimage, ...)
@@ -12,6 +13,8 @@
 \S4method{gg_annotation_raster}{gg,giottoImage}(ggobj, gimage, ...)
 
 \S4method{gg_annotation_raster}{gg,giottoLargeImage}(ggobj, gimage, ext = NULL, ...)
+
+\S4method{gg_annotation_raster}{gg,giottoAffineImage}(ggobj, gimage, ext, ...)
 }
 \arguments{
 \item{ggobj}{ggplot2 \code{gg} object}


### PR DESCRIPTION
## enhancements
- `giottoLargeImage` `max_window` and `colors` slot info is now followed during ggplot plotting
-  `giottoAffineImage` (GiottoClass 0.3.2 dev) compatibility for giotto ggplot2 plotting functions

## new
- `geom_text_repel()` and `geom_label_repel()` from `ggplot2` are now re-exported