### PR TITLE
v0.2.15

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@
 ^pkgdown$
 ^\.github$
 testout
+^\.positai$
+^\.claude$

--- a/.github/workflows/covr.yml
+++ b/.github/workflows/covr.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up dependencies (GiottoData)
         run: |
           suppressWarnings({
-            remotes::install_github('drieslab/GiottoData', build = FALSE)
+            remotes::install_github('giotto-suite/GiottoData', build = FALSE)
           })
         shell: Rscript {0}
 

--- a/.github/workflows/dev_check.yml
+++ b/.github/workflows/dev_check.yml
@@ -54,21 +54,21 @@ jobs:
       - name: Set up dependencies (GiottoUtils)
         run: |
           suppressWarnings({
-            remotes::install_github('drieslab/GiottoUtils', build = FALSE)
+            remotes::install_github('giotto-suite/GiottoUtils', build = FALSE)
           })
         shell: Rscript {0}
 
       - name: Set up dependencies (GiottoClass)
         run: |
           suppressWarnings({
-            remotes::install_github('drieslab/GiottoClass', build = FALSE)
+            remotes::install_github('giotto-suite/GiottoClass', build = FALSE)
           })
         shell: Rscript {0}
 
       - name: Set up dependencies (GiottoData)
         run: |
           suppressWarnings({
-            remotes::install_github('drieslab/GiottoData', build = FALSE)
+            remotes::install_github('giotto-suite/GiottoData', build = FALSE)
           })
         shell: Rscript {0}
 

--- a/.github/workflows/main_check.yml
+++ b/.github/workflows/main_check.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Set up dependencies (GiottoData)
         run: |
           suppressWarnings({
-            remotes::install_github('drieslab/GiottoData', build = FALSE)
+            remotes::install_github('giotto-suite/GiottoData', build = FALSE)
           })
         shell: Rscript {0}
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ inst/doc
 .Rprofile
 docs
 testout
+.positai

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,8 +18,8 @@ Authors@R: c(
 Description: Expanded visualization and plotting functionality for Giotto Suite.
 License: MIT + file LICENSE
 Encoding: UTF-8
-URL: https://drieslab.github.io/Giotto/, https://github.com/drieslab/Giotto, https://drieslab.github.io/GiottoVisuals/
-BugReports: https://github.com/drieslab/Giotto/issues
+URL: https://giotto-suite.github.io/Giotto/, https://github.com/giotto-suite/Giotto, https://giotto-suite.github.io/GiottoVisuals/
+BugReports: https://github.com/giotto-suite/Giotto/issues
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Depends:
@@ -68,8 +68,8 @@ Suggests:
     knitr,
     rmarkdown
 Remotes:
-    drieslab/GiottoUtils,
-    drieslab/GiottoClass
+    giotto-suite/GiottoUtils,
+    giotto-suite/GiottoClass
 Config/testthat/edition: 3
 Collate: 
     'aux_defaults.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     data.table,
     ggplot2 (>= 3.1.1),
     GiottoUtils (>= 0.1.12),
-    GiottoClass (>= 0.3.6),
+    GiottoClass (>= 0.5.1),
     ggrepel,
     igraph (>= 1.2.4.1),
     methods,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GiottoVisuals
 Title: Visuals for the Giotto spatial biology analysis ecosystem
-Version: 0.2.14
+Version: 0.2.15
 Authors@R: c(
 	person("Ruben", "Dries", email = "rubendries@gmail.com",
 		 role = c("aut", "cre"), comment = c(ORCID = "0000-0001-7650-7754")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@
 
 ## changes
 - change `spatInSituPlotPoints()` param `spat_enr_names` to `spat_enr_name`
+- `auto_image_resample()`
+  - Rewritten to use `terra::window()` instead of the two-method crop/oversample approach, simplifying the implementation and avoiding materialization of large crops to disk
+  - Removed params: `flex_resample`, `max_crop`, `max_resample_scale` and their corresponding global options `giotto.plot_img_max_crop` and `giotto.plot_img_max_resample_scale`.
+- feature value collection in `spatFeatPlot2D_single()`, `dimFeatPlot2D()`, `spatFeatPlot3D()`, `dimFeatPlot3D()`, and `spatDimFeatPlot3D()` now uses `spatValues()`, replacing manual expression matrix extraction and transposition
+- minimum GiottoClass version bumped to `>= 0.5.1`
 
 ## enhancements
 - `show_axes` param for `spatInSituPlotPoints()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
-# GiottoVisuals 0.2.15
+# GiottoVisuals 0.2.15 (2026/05/14)
 
 ## bug fixes
 - fix color gradient error when GiottoVisuals is not attached (loaded as dependency or via `::`): `giotto.color_cd_pal` and `giotto.color_cs_pal` options now have inline fallback defaults in `set_default_color_continuous()`
+- `aes_string2()` fixed handling for column names that parse as numeric literals (e.g. "1", "2") that caused plotting to fail
 
 ## changes
 - `auto_image_resample()` rewritten to use `terra::window()` instead of the two-method crop/oversample approach, simplifying the implementation and avoiding materialization of large crops to disk. `giottoAffineImage` is now also supported. Removed params: `flex_resample`, `max_crop`, `max_resample_scale` and their corresponding global options `giotto.plot_img_max_crop` and `giotto.plot_img_max_resample_scale`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # GiottoVisuals 0.2.15
 
+## bug fixes
+- fix color gradient error when GiottoVisuals is not attached (loaded as dependency or via `::`): `giotto.color_cd_pal` and `giotto.color_cs_pal` options now have inline fallback defaults in `set_default_color_continuous()`
+
 ## changes
 - `auto_image_resample()` rewritten to use `terra::window()` instead of the two-method crop/oversample approach, simplifying the implementation and avoiding materialization of large crops to disk. `giottoAffineImage` is now also supported. Removed params: `flex_resample`, `max_crop`, `max_resample_scale` and their corresponding global options `giotto.plot_img_max_crop` and `giotto.plot_img_max_resample_scale`.
 - feature value collection in `spatFeatPlot2D_single()`, `dimFeatPlot2D()`, `spatFeatPlot3D()`, `dimFeatPlot3D()`, `spatDimFeatPlot3D()`, and `violinPlot()` now uses `spatValues()`, replacing manual expression matrix extraction and transposition

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,17 @@
-# GiottoVisuals 0.2.14
+# GiottoVisuals 0.2.15
+
+## changes
+- `auto_image_resample()` rewritten to use `terra::window()` instead of the two-method crop/oversample approach, simplifying the implementation and avoiding materialization of large crops to disk. `giottoAffineImage` is now also supported. Removed params: `flex_resample`, `max_crop`, `max_resample_scale` and their corresponding global options `giotto.plot_img_max_crop` and `giotto.plot_img_max_resample_scale`.
+- feature value collection in `spatFeatPlot2D_single()`, `dimFeatPlot2D()`, `spatFeatPlot3D()`, `dimFeatPlot3D()`, `spatDimFeatPlot3D()`, and `violinPlot()` now uses `spatValues()`, replacing manual expression matrix extraction and transposition
+- minimum GiottoClass version bumped to `>= 0.5.1`
+
+# GiottoVisuals 0.2.14 (2025/11/19)
 
 ## bug fixes
 - allow `coord_fix_ratio = TRUE` usage again after ggplot2 changes
 
 ## changes
 - change `spatInSituPlotPoints()` param `spat_enr_names` to `spat_enr_name`
-- `auto_image_resample()`
-  - Rewritten to use `terra::window()` instead of the two-method crop/oversample approach, simplifying the implementation and avoiding materialization of large crops to disk
-  - Removed params: `flex_resample`, `max_crop`, `max_resample_scale` and their corresponding global options `giotto.plot_img_max_crop` and `giotto.plot_img_max_resample_scale`.
-- feature value collection in `spatFeatPlot2D_single()`, `dimFeatPlot2D()`, `spatFeatPlot3D()`, `dimFeatPlot3D()`, and `spatDimFeatPlot3D()` now uses `spatValues()`, replacing manual expression matrix extraction and transposition
-- minimum GiottoClass version bumped to `>= 0.5.1`
 
 ## enhancements
 - `show_axes` param for `spatInSituPlotPoints()`

--- a/R/aux_defaults.R
+++ b/R/aux_defaults.R
@@ -380,8 +380,8 @@ set_default_color_continuous <- function(
 
     # global giotto options
     opt_pal <- switch(style,
-        "divergent" = getOption("giotto.color_cd_pal"),
-        "sequential" = getOption("giotto.color_cs_pal")
+        "divergent" = getOption("giotto.color_cd_pal", c("blue", "white", "red")),
+        "sequential" = getOption("giotto.color_cs_pal", "viridis")
     )
 
     opt_rev <- getOption("giotto.color_c_rev", FALSE)

--- a/R/aux_visuals.R
+++ b/R/aux_visuals.R
@@ -194,7 +194,12 @@ aes_string2 <- function(x, y, ...) {
             if (identical(x, "")) {
                 stop("[aes_string2] empty string not allowed", call. = FALSE)
             }
-            x <- str2lang(x)
+            parsed <- str2lang(x)
+            x <- if (is.symbol(parsed) || is.call(parsed)) {
+                parsed
+            }  else {
+                as.name(x)
+            }
         }
         x
     })

--- a/R/gg_annotation_raster.R
+++ b/R/gg_annotation_raster.R
@@ -16,8 +16,7 @@
 #' @param \dots additional params to pass
 #' @details
 #' No ... params are implemented for `giottoImage`. \cr ... params for
-#' `giottoLargeImage` passes to automated resampling params see
-#' `?auto_image_resample` for details
+#' `giottoLargeImage` and `giottoAffineImage` pass to `?auto_image_resample`
 #' @return `gg` object with images to plot appended as annotation rasters
 #' @examples
 #' gimg <- GiottoData::loadSubObjectMini("giottoLargeImage")
@@ -87,7 +86,6 @@ setMethod(
         gimage <- .auto_resample_gimage(
             img = gimage,
             plot_ext = ext,
-            crop_ratio_fun = .img_to_crop_ratio_gimage,
             sample_fun = .sample_gimage,
             ...
         )
@@ -114,7 +112,6 @@ setMethod(
         gimage <- .auto_resample_gimage(
             img = gimage,
             plot_ext = ext,
-            crop_ratio_fun = .img_to_crop_ratio_gaffimage,
             sample_fun = .sample_gaffimage,
             ...
         )
@@ -189,199 +186,66 @@ setMethod(
 #' @name auto_image_resample
 #' @title Optimized image resampling
 #' @description
-#' Downsample terra-based images for plotting. Uses
-#' \code{\link[terra]{spatSample}} to load onlya  portion of the original image,
-#' speeding up plotting and lowering memory footprint.
-#'
-#' Default behavior of `spatSample` is to crop if only a smaller ROI is
-#' needed for plotting followed by the sampling process in order to reduce
-#' wasted sampling by focusing the sample space. For very large ROIs, this
-#' crop can be time intensive and require writing to disk.
-#'
-#' This function examines the ROI dimensions as defined through the limits of
-#' the spatial locations to be plotted, and decides between the following two
-#' methods in order to avoid this issue:
-#' \itemize{
-#'     \item{\strong{Method A.} First crop original image, then sample
-#'     `max_sample` (default = 5e5) values to generate final image. Intended
-#'     for smaller ROIs. Force usage of this method by setting
-#'     `flex_resample = FALSE`}
-#'     \item{\strong{Method B.} First oversample, then crop. Intended for larger
-#'     ROIs. Base sample size is `max_sample`, which is then multiplied by a
-#'     scale factor >1 that increases the smaller the ROI is and is defined by:
-#'     original dimensions/crop dimensions where the larger ratio between x
-#'     and y dims is chosen. Scale factor is capped by
-#'     \code{max_resample_scale}}
-#' }
-#' Control points for this function are set by \code{max_crop} which decides
-#' the max ROI area after which switchover to method B happens in order to
-#' avoid laborious crops and \code{max_resample_scale} which determines the
-#' maximum scale factor for number of values to sample. Both values can be
-#' adjusted depending on system resources. Additionally, \code{flex_resample}
-#' determines if this switching behavior happens.
-#' When set to \code{FALSE}, only method A is used.
+#' Downsample terra-based images for plotting. Uses \code{\link[terra]{window}}
+#' to set a virtual reading window on the image before calling
+#' \code{\link[terra]{spatSample}}, so only the relevant spatial ROI is read
+#' from disk. This avoids materializing a crop to disk for large ROIs while
+#' still focusing sampling on the plot region.
 #' @param img giotto image to plot
 #' @param plot_ext extent of plot (defaults to the image extent)
-#' @param img_border if not 0 or FALSE, expand plot_ext by this percentage on
-#' each side before applying crop on image. See details
-#' @param flex_resample logical. Default = TRUE. Forces usage of method A when
-#' FALSE.
-#' @param max_sample numeric. Default = 5e5. Maximum n values to sample from the
-#' image. If larger than `max_crop`, will override `max_crop.`
-#' Globally settable with the option "giotto.plot_img_max_sample"
-#' @param max_crop numeric. Default = 1e8. Maximum crop size (px area) allowed
-#' for \strong{method A} before switching to \strong{method B}
-#' (see description).
-#' Globally settable with option "giotto.plot_img_max_crop"
-#' @param max_resample_scale numeric. Default = 100. Maximum scalefactor allowed
-#' to be applied on `max_sample` in order to oversample when compensating
-#' for decreased resolution when cropping after sampling. Globally settable with
-#' option "giotto.plot_img_max_resample_scale".
+#' @param img_border numeric. Default = 0.125. If greater than 0, expand
+#' `plot_ext` by this fraction on each side before setting the window. See
+#' details.
+#' @param max_sample numeric. Default = 5e5. Maximum number of values to sample
+#' from the image. Globally settable with option "giotto.plot_img_max_sample"
 #' @details
 #' **img_border**
-#' expand ext to use for plotting the image. This makes it so that the image
-#' is not cut off sharply at the edge of the plot extent. Needed since plots
-#' often define extent by centroids, and polygons may hang over the edge of the
-#' extent.
-#' @returns a giotto image cropped and resampled properly for plotting
+#' Expands the window extent used for reading the image. This prevents the
+#' image from being cut off sharply at the plot boundary, since plot extents
+#' are typically defined by centroids and polygons may hang over the edge.
+#' @returns a giotto image resampled within the plot window
 #' @examples
 #' \dontrun{
 #' img <- GiottoData::loadSubObjectMini("giottoLargeImage")
 #' .auto_resample_gimage(img)
 #' }
-#' @seealso \code{\link[terra]{spatSample}}
+#' @seealso \code{\link[terra]{window}}, \code{\link[terra]{spatSample}}
 #' @keywords internal
 .auto_resample_gimage <- function(img,
     plot_ext = NULL,
     img_border = 0.125,
-    crop_ratio_fun = .img_to_crop_ratio_gimage,
     sample_fun = .sample_gimage,
-    flex_resample = TRUE,
-    max_sample = getOption("giotto.plot_img_max_sample", 5e5),
-    max_crop = getOption("giotto.plot_img_max_crop", 1e8),
-    max_resample_scale = getOption(
-        "giotto.plot_img_max_resample_scale", 100
-    )) {
-    # 1. determine source image and cropping extents
-    if (is.null(plot_ext)) {
-        crop_ext <- ext(img)
-    } # default to img extent
-    else {
-        crop_ext <- ext(plot_ext)
-    }
-    bound_poly <- as.polygons(crop_ext)
-
-    # 1.1. override max_crop if needed
-    if (max_sample > max_crop) max_crop <- max_sample
-
-    # 1.2. apply img border expansion
-    # - note: cropping with extent larger than the image extent is supported
-    if (img_border > 0) {
-        crop_ext <- bound_poly %>%
-            rescale(1 + img_border) %>%
-            ext()
-
-        # determine final crop (normalizes extent when larger than available)
-        crop_ext <- ext(crop(bound_poly, crop_ext))
+    max_sample = getOption("giotto.plot_img_max_sample", 5e5)) {
+    # determine ext to use
+    crop_ext <- if (is.null(plot_ext)) {
+        ext(img) # fallback to img extent
+    } else {
+        plot_ext <- ext(plot_ext) # if ext specified
+        if (img_border > 0) { # apply border expansion
+            plot_ext <- plot_ext |>
+                as.polygons() |>
+                rescale(1 + img_border) |>
+                ext()
+        }
+        # normalize extent when larger than available
+        terra::intersect(ext(img), plot_ext) # NULL if no intersect
     }
 
-    # 1.3 check intersects
-    if (!relate(crop_ext, ext(img), relation = "intersects")[1]) {
-        warning("image '", objName(img), "' is not within the plotting window",
-                call. = FALSE)
+    # check image is in plot_ext
+    if (is.null(crop_ext)) {
+        warning(sprintf("image '%s' is not within the plotting window", 
+            objName(img)), call. = FALSE)
         return(NULL)
     }
 
-    # 2. determine cropping area
-    original_dims <- dim(img)[c(2L, 1L)] # x, y ordering
-    ratios <- crop_ratio_fun(img = img, crop_ext = crop_ext) # x, y ordering
-    crop_dims <- original_dims * ratios
-    crop_area_px <- prod(crop_dims)
-
-    # 3. perform flexible resample/crop based on cropping area
-    if (!isTRUE(flex_resample) || crop_area_px <= max_crop) {
-        # [METHOD A]:
-        # 1. Crop if needed
-        # 2. resample to final image
-        if (!isTRUE(flex_resample) && crop_area_px > max_crop) {
-            warning(
-                "Plotting large regions with flex_resample == FALSE will\n ",
-                "increase time and may require scratch space."
-            )
-        }
-
-        vmsg(
-            .is_debug = TRUE,
-            sprintf(
-                "img auto_res: [A] | area: %f | max: %f",
-                crop_area_px, max_crop
-            )
-        )
-
-        crop_img <- terra::crop(img, crop_ext)
-        res <- sample_fun(crop_img, size = max_sample)
-    } else {
-        # [METHOD B]:
-        # 1. Oversample
-        # 2. crop to final image
-        # Sample n values where max_sample is scaled by a value >1
-        # Scale factor is fullsize image dim/crop dim. Larger of the two
-        # ratios is chosen
-        scalef <- max(1 / ratios)
-        # This scaling is ALSO capped by max_resample_scale
-        if (scalef > max_resample_scale) scalef <- max_resample_scale
-
-        vmsg(
-            .is_debug = TRUE,
-            sprintf(
-                "img auto_res: [B] | scalef: %f | max_scale: %f",
-                scalef, max_resample_scale
-            )
-        )
-
-        oversample_img <- sample_fun(img, size = round(max_sample * scalef))
-        res <- terra::crop(oversample_img, crop_ext)
-    }
-    return(res)
+    img <- crop(img, crop_ext)
+    sample_fun(img, size = max_sample)
 }
 
-
-
-
-# determine ratio of crop vs full image extent
-.img_to_crop_ratio_gimage <- function(img, crop_ext) {
-    img_ext <- ext(img)
-    ratio <- range(crop_ext) / range(img_ext)
-    # crops larger than the image are possible, but meaningless for this
-    # calculate. so the ratios are capped at 1.
-    ratio[ratio > 1] <- 1
-    return(ratio)
-}
-
-.img_to_crop_ratio_gaffimage <- function(img, crop_ext) {
-    # Do not use the ext() method for giottoAffineImage
-    # Instead use the mapping applied to the underlying SpatRaster.
-    # For giottoAffineImage, these two values are usually different.
-    img_ext <- ext(img@raster_object)
-    # find the extent needed in the source (untransformed) image
-    crop_bound <- terra::as.polygons(crop_ext)
-    crop_bound$id <- "bound" # affine() requires ID values
-    crop_ext <- ext(affine(crop_bound, img@affine, inv = TRUE))
-    ratio <- range(crop_ext) / range(img_ext)
-    # crops larger than the image are possible, but meaningless for this
-    # calculate. so the ratios are capped at 1.
-    ratio[ratio > 1] <- 1
-    return(ratio)
-}
-
-
-
-
-# pull sampled values from original image into target spatial mapping
-# should return a giottoLargeImage
+# Pull sampled values from original image into target spatial mapping
+# Returns a `giottoLargeImage`
 .sample_gimage <- function(x, size) {
-    x@raster_object <- terra::spatSample(
-        x = x@raster_object,
+    x[] <- terra::spatSample(x[],
         size = size,
         method = "regular",
         as.raster = TRUE

--- a/R/plot_violin.R
+++ b/R/plot_violin.R
@@ -71,57 +71,37 @@ violinPlot <- function(gobject,
             expression_values
         ))
     )
-    expr_data <- getExpression(
-        gobject = gobject,
-        feat_type = feat_type,
+
+    # collect expression values using spatValues
+    expr_dt <- spatValues(gobject,
+        feats = unique(feats),
         spat_unit = spat_unit,
-        values = values,
-        output = "matrix"
+        feat_type = feat_type,
+        expression_values = values,
+        verbose = FALSE
     )
+    selected_feats <- setdiff(colnames(expr_dt), "cell_ID")
 
-    # only keep feats that are in the dataset
-    selected_feats <- feats[feats %in% rownames(expr_data)]
-    dup_feats <- selected_feats[duplicated(selected_feats)]
-    if (length(dup_feats) != 0) {
-        message(
-            "These feats have duplicates: \n",
-            paste(dup_feats, collapse = ", ")
-        )
-        selected_feats <- unique(selected_feats)
-    }
-
-    # stop and provide warning if no feats have been found
+    # stop if no feats have been found
     if (length(selected_feats) == 0) {
         stop("No overlapping features have been found,
             check inputer for parameter 'feats'")
     }
 
-    subset_data <-
-        as.matrix(expr_data[rownames(expr_data) %in% selected_feats, ])
-
-    if (length(feats) == 1) {
-        t_subset_data <- subset_data
-    } else {
-        t_subset_data <- t_flex(subset_data)
-    }
-
-    # metadata
-    metadata <- pDataDT(gobject,
+    # cluster column
+    clus_dt <- spatValues(gobject,
+        feats = cluster_column,
+        spat_unit = spat_unit,
         feat_type = feat_type,
-        spat_unit = spat_unit
+        verbose = FALSE
     )
 
-    if (length(feats) == 1) {
-        metadata_expr <- cbind(metadata, t_subset_data)
-        data.table::setnames(metadata_expr, "V1", feats)
-    } else {
-        metadata_expr <- cbind(metadata, t_subset_data)
-    }
+    metadata_expr <- clus_dt[expr_dt, on = "cell_ID"]
 
 
     metadata_expr_m <-
         data.table::melt.data.table(metadata_expr,
-            measure.vars = unique(selected_feats),
+            measure.vars = selected_feats,
             variable.name = "feats"
         )
     metadata_expr_m[, feats := factor(feats, selected_feats)]

--- a/R/vis_spatial_gg.R
+++ b/R/vis_spatial_gg.R
@@ -2495,40 +2495,17 @@ spatFeatPlot2D_single <- function(
             expression_values
         ))
     )
-    expr_values <- getExpression(
-        gobject = gobject,
+
+    # collect feature values using spatValues
+    t_sub_expr_data_DT <- spatValues(
+        gobject,
+        feats = feats,
         spat_unit = spat_unit,
         feat_type = feat_type,
-        values = values,
-        output = "matrix"
+        expression_values = values,
+        verbose = FALSE
     )
-
-    # only keep feats that are in the dataset
-    selected_feats <- feats
-    selected_feats <- selected_feats[selected_feats %in% rownames(expr_values)]
-
-
-    # get selected feat expression values in data.table format
-    if (length(selected_feats) == 1) {
-        subset_expr_data <- expr_values[rownames(expr_values) %in%
-            selected_feats, ]
-        t_sub_expr_data_DT <- data.table::data.table(
-            "selected_feat" = subset_expr_data,
-            "cell_ID" = colnames(expr_values)
-        )
-        data.table::setnames(
-            t_sub_expr_data_DT, "selected_feat",
-            selected_feats
-        )
-    } else {
-        subset_expr_data <- expr_values[rownames(expr_values) %in%
-            selected_feats, ]
-        t_sub_expr_data <- t_flex(subset_expr_data)
-        t_sub_expr_data_DT <- data.table::as.data.table(
-            as.matrix(t_sub_expr_data)
-        )
-        t_sub_expr_data_DT[, cell_ID := rownames(t_sub_expr_data)]
-    }
+    selected_feats <- setdiff(colnames(t_sub_expr_data_DT), "cell_ID")
 
 
     ## extract cell locations
@@ -3595,52 +3572,28 @@ dimFeatPlot2D <- function(
                 expression_values
             ))
         )
-        expr_values <- getExpression(
-            gobject = gobject,
-            spat_unit = spat_unit,
-            feat_type = feat_type,
-            values = values,
-            output = "matrix"
-        )
 
-        # only keep feats that are in the dataset
+        # data.table variables
+        cell_ID <- NULL
+
         if (length(feats) == 0) {
             stop("No `feats` selected to plot.", call. = FALSE)
         }
-        selected_feats <- feats
-        selected_feats <- selected_feats[
-            selected_feats %in% rownames(expr_values)]
+
+        # collect feature values using spatValues
+        t_sub_expr_data_DT <- spatValues(
+            gobject,
+            feats = feats,
+            spat_unit = spat_unit,
+            feat_type = feat_type,
+            expression_values = values,
+            verbose = FALSE
+        )
+        selected_feats <- setdiff(colnames(t_sub_expr_data_DT), "cell_ID")
         if (length(selected_feats) == 0) {
             stop("Selected `feats` not found in expression information",
                 call. = FALSE
             )
-        }
-
-        #
-        if (length(selected_feats) == 1) {
-            subset_expr_data <- expr_values[
-                rownames(expr_values) %in% selected_feats,
-            ]
-            t_sub_expr_data_DT <- data.table::data.table(
-                "selected_feat" = subset_expr_data,
-                "cell_ID" = colnames(expr_values)
-            )
-            data.table::setnames(
-                t_sub_expr_data_DT, "selected_feat",
-                selected_feats
-            )
-        } else {
-            subset_expr_data <- expr_values[
-                rownames(expr_values) %in% selected_feats, ]
-            t_sub_expr_data <- t_flex(subset_expr_data)
-            t_sub_expr_data_DT <- data.table::as.data.table(
-                as.matrix(t_sub_expr_data)
-            )
-
-            # data.table variables
-            cell_ID <- NULL
-
-            t_sub_expr_data_DT[, cell_ID := rownames(t_sub_expr_data)]
         }
 
 

--- a/R/vis_spatial_plotly.R
+++ b/R/vis_spatial_plotly.R
@@ -2739,43 +2739,20 @@ spatFeatPlot3D <- function(
     # data.table variables
     cell_ID <- NULL
 
-    selected_genes <- feats
-
     values <- match.arg(expression_values,
         unique(c("normalized", "scaled", "custom", expression_values))
     )
-    expr_values <- getExpression(
-        gobject = gobject,
+
+    # collect feature values using spatValues
+    t_sub_expr_data_DT <- spatValues(
+        gobject,
+        feats = feats,
         spat_unit = spat_unit,
         feat_type = feat_type,
-        values = values,
-        output = "matrix"
+        expression_values = values,
+        verbose = FALSE
     )
-
-    # only keep genes that are in the dataset
-    selected_genes <- selected_genes[selected_genes %in% rownames(expr_values)]
-
-    # get selected feature expression values in data.table format
-    if (length(selected_genes) == 1) {
-        subset_expr_data <- expr_values[rownames(expr_values) %in%
-            selected_genes, ]
-        t_sub_expr_data_DT <- data.table::data.table(
-            "selected_gene" = subset_expr_data,
-            "cell_ID" = colnames(expr_values)
-        )
-        data.table::setnames(
-            t_sub_expr_data_DT,
-            "selected_gene", selected_genes
-        )
-    } else {
-        subset_expr_data <- expr_values[rownames(expr_values) %in%
-            selected_genes, ]
-        t_sub_expr_data <- t_flex(subset_expr_data)
-        t_sub_expr_data_DT <- data.table::as.data.table(
-            as.matrix(t_sub_expr_data)
-        )
-        t_sub_expr_data_DT[, cell_ID := rownames(t_sub_expr_data)]
-    }
+    selected_genes <- setdiff(colnames(t_sub_expr_data_DT), "cell_ID")
 
 
     ## extract cell locations
@@ -3230,46 +3207,22 @@ dimFeatPlot3D <- function(
         feat_type = feat_type
     )
 
+    # data.table variables
+    cell_ID <- NULL
+
     ## select genes ##
-    selected_genes <- genes
     values <- match.arg(expression_values, c("normalized", "scaled", "custom"))
-    expr_values <- getExpression(
-        gobject = gobject,
+
+    # collect feature values using spatValues
+    t_sub_expr_data_DT <- spatValues(
+        gobject,
+        feats = genes,
         spat_unit = spat_unit,
         feat_type = feat_type,
-        values = values,
-        output = "matrix"
+        expression_values = values,
+        verbose = FALSE
     )
-
-    # only keep genes that are in the dataset
-    selected_genes <- selected_genes[selected_genes %in% rownames(expr_values)]
-
-    #
-    if (length(selected_genes) == 1) {
-        subset_expr_data <- expr_values[
-            rownames(expr_values) %in% selected_genes,
-        ]
-        t_sub_expr_data_DT <- data.table::data.table(
-            "selected_gene" = subset_expr_data,
-            "cell_ID" = colnames(expr_values)
-        )
-        data.table::setnames(
-            t_sub_expr_data_DT, "selected_gene", selected_genes
-        )
-    } else {
-        subset_expr_data <- expr_values[
-            rownames(expr_values) %in% selected_genes,
-        ]
-        t_sub_expr_data <- t_flex(subset_expr_data)
-        t_sub_expr_data_DT <- data.table::as.data.table(
-            as.matrix(t_sub_expr_data)
-        )
-
-        # data.table variables
-        cell_ID <- NULL
-
-        t_sub_expr_data_DT[, cell_ID := rownames(t_sub_expr_data)]
-    }
+    selected_genes <- setdiff(colnames(t_sub_expr_data_DT), "cell_ID")
 
 
     ## dimension reduction ##
@@ -3730,23 +3683,18 @@ spatDimFeatPlot3D <- function(
                 gene will be plot\n")
         genes <- genes[1]
     }
-    selected_genes <- genes
     values <- match.arg(expression_values, c("normalized", "scaled", "custom"))
-    expr_values <- getExpression(
-        gobject = gobject,
+
+    # collect feature values using spatValues
+    t_sub_expr_data_DT <- spatValues(
+        gobject,
+        feats = genes,
         spat_unit = spat_unit,
         feat_type = feat_type,
-        values = values,
-        output = "matrix"
+        expression_values = values,
+        verbose = FALSE
     )
-
-    # only keep genes that are in the dataset
-    selected_genes <- selected_genes[selected_genes %in% rownames(expr_values)]
-    subset_expr_data <- expr_values[rownames(expr_values) %in% selected_genes, ]
-    t_sub_expr_data_DT <- data.table::data.table(
-        "selected_gene" = subset_expr_data, "cell_ID" = colnames(expr_values)
-    )
-    data.table::setnames(t_sub_expr_data_DT, "selected_gene", selected_genes)
+    selected_genes <- setdiff(colnames(t_sub_expr_data_DT), "cell_ID")
 
 
     ## dimension reduction ##

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -25,8 +25,6 @@
 
     # image resampling
     init_option("giotto.plot_img_max_sample", 5e5)
-    init_option("giotto.plot_img_max_crop", 1e8)
-    init_option("giotto.plot_img_max_resample_scale", 100)
 
     # point rasterization
     init_option("giotto.plot_point_raster", 5e5)

--- a/README.Rmd
+++ b/README.Rmd
@@ -16,12 +16,12 @@ knitr::opts_chunk$set(
 # GiottoVisuals <img src="man/figures/logo.png" align="right" alt="" width="160" />
 
 <!-- badges: start -->
-![Version](https://img.shields.io/github/r-package/v/drieslab/GiottoVisuals)
+![Version](https://img.shields.io/github/r-package/v/giotto-suite/GiottoVisuals)
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![codecov](https://codecov.io/github/drieslab/GiottoVisuals/graph/badge.svg?token=F4ga1Ahbhw)](https://codecov.io/github/drieslab/GiottoVisuals)
-[![R-CMD-check](https://github.com/drieslab/GiottoVisuals/actions/workflows/main_check.yml/badge.svg)](https://github.com/drieslab/GiottoVisuals/actions/workflows/main_check.yml)
-[![GitHub issues](https://img.shields.io/github/issues/drieslab/Giotto)](https://github.com/drieslab/Giotto/issues)
-[![GitHub pulls](https://img.shields.io/github/issues-pr/drieslab/GiottoVisuals)](https://github.com/drieslab/GiottoVisuals/pulls)
+[![codecov](https://codecov.io/github/giotto-suite/GiottoVisuals/graph/badge.svg?token=F4ga1Ahbhw)](https://codecov.io/github/giotto-suite/GiottoVisuals)
+[![R-CMD-check](https://github.com/giotto-suite/GiottoVisuals/actions/workflows/main_check.yml/badge.svg)](https://github.com/giotto-suite/GiottoVisuals/actions/workflows/main_check.yml)
+[![GitHub issues](https://img.shields.io/github/issues/giotto-suite/Giotto)](https://github.com/giotto-suite/Giotto/issues)
+[![GitHub pulls](https://img.shields.io/github/issues-pr/giotto-suite/GiottoVisuals)](https://github.com/giotto-suite/GiottoVisuals/pulls)
 <!-- badges: end -->
 
 GiottoVisuals contains the main plotting functions of Giotto Suite
@@ -32,7 +32,7 @@ You can install GiottoVisuals like:
 
 ``` r
 if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
-pak::pak("drieslab/GiottoVisuals")
+pak::pak("giotto-suite/GiottoVisuals")
 ```
 
 ## Script Organization by Prefixes:

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 
 <!-- badges: start -->
 
-![Version](https://img.shields.io/github/r-package/v/drieslab/GiottoVisuals)
+![Version](https://img.shields.io/github/r-package/v/giotto-suite/GiottoVisuals)
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
-[![codecov](https://codecov.io/github/drieslab/GiottoVisuals/graph/badge.svg?token=F4ga1Ahbhw)](https://codecov.io/github/drieslab/GiottoVisuals)
-[![R-CMD-check](https://github.com/drieslab/GiottoVisuals/actions/workflows/main_check.yml/badge.svg)](https://github.com/drieslab/GiottoVisuals/actions/workflows/main_check.yml)
+[![codecov](https://codecov.io/github/giotto-suite/GiottoVisuals/graph/badge.svg?token=F4ga1Ahbhw)](https://codecov.io/github/giotto-suite/GiottoVisuals)
+[![R-CMD-check](https://github.com/giotto-suite/GiottoVisuals/actions/workflows/main_check.yml/badge.svg)](https://github.com/giotto-suite/GiottoVisuals/actions/workflows/main_check.yml)
 [![GitHub
-issues](https://img.shields.io/github/issues/drieslab/Giotto)](https://github.com/drieslab/Giotto/issues)
+issues](https://img.shields.io/github/issues/giotto-suite/Giotto)](https://github.com/giotto-suite/Giotto/issues)
 [![GitHub
-pulls](https://img.shields.io/github/issues-pr/drieslab/GiottoVisuals)](https://github.com/drieslab/GiottoVisuals/pulls)
+pulls](https://img.shields.io/github/issues-pr/giotto-suite/GiottoVisuals)](https://github.com/giotto-suite/GiottoVisuals/pulls)
 <!-- badges: end -->
 
 GiottoVisuals contains the main plotting functions of Giotto Suite
@@ -24,7 +24,7 @@ You can install GiottoVisuals like:
 
 ``` r
 if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
-pak::pak("drieslab/GiottoVisuals")
+pak::pak("giotto-suite/GiottoVisuals")
 ```
 
 ## Script Organization by Prefixes:

--- a/inst/pkgdown.yml
+++ b/inst/pkgdown.yml
@@ -4,6 +4,6 @@ pkgdown_sha: ~
 articles: {}
 last_built: 2023-12-05T20:41Z
 urls:
-  reference: https://drieslab.github.io/GiottoVisuals/reference
-  article: https://drieslab.github.io/GiottoVisuals/articles
+  reference: https://giotto-suite.github.io/GiottoVisuals/reference
+  article: https://giotto-suite.github.io/GiottoVisuals/articles
 

--- a/man/auto_image_resample.Rd
+++ b/man/auto_image_resample.Rd
@@ -9,12 +9,8 @@
   img,
   plot_ext = NULL,
   img_border = 0.125,
-  crop_ratio_fun = .img_to_crop_ratio_gimage,
   sample_fun = .sample_gimage,
-  flex_resample = TRUE,
-  max_sample = getOption("giotto.plot_img_max_sample", 5e+05),
-  max_crop = getOption("giotto.plot_img_max_crop", 1e+08),
-  max_resample_scale = getOption("giotto.plot_img_max_resample_scale", 100)
+  max_sample = getOption("giotto.plot_img_max_sample", 5e+05)
 )
 }
 \arguments{
@@ -22,68 +18,28 @@
 
 \item{plot_ext}{extent of plot (defaults to the image extent)}
 
-\item{img_border}{if not 0 or FALSE, expand plot_ext by this percentage on
-each side before applying crop on image. See details}
+\item{img_border}{numeric. Default = 0.125. If greater than 0, expand
+\code{plot_ext} by this fraction on each side before setting the window. See
+details.}
 
-\item{flex_resample}{logical. Default = TRUE. Forces usage of method A when
-FALSE.}
-
-\item{max_sample}{numeric. Default = 5e5. Maximum n values to sample from the
-image. If larger than \code{max_crop}, will override \code{max_crop.}
-Globally settable with the option "giotto.plot_img_max_sample"}
-
-\item{max_crop}{numeric. Default = 1e8. Maximum crop size (px area) allowed
-for \strong{method A} before switching to \strong{method B}
-(see description).
-Globally settable with option "giotto.plot_img_max_crop"}
-
-\item{max_resample_scale}{numeric. Default = 100. Maximum scalefactor allowed
-to be applied on \code{max_sample} in order to oversample when compensating
-for decreased resolution when cropping after sampling. Globally settable with
-option "giotto.plot_img_max_resample_scale".}
+\item{max_sample}{numeric. Default = 5e5. Maximum number of values to sample
+from the image. Globally settable with option "giotto.plot_img_max_sample"}
 }
 \value{
-a giotto image cropped and resampled properly for plotting
+a giotto image resampled within the plot window
 }
 \description{
-Downsample terra-based images for plotting. Uses
-\code{\link[terra]{spatSample}} to load onlya  portion of the original image,
-speeding up plotting and lowering memory footprint.
-
-Default behavior of \code{spatSample} is to crop if only a smaller ROI is
-needed for plotting followed by the sampling process in order to reduce
-wasted sampling by focusing the sample space. For very large ROIs, this
-crop can be time intensive and require writing to disk.
-
-This function examines the ROI dimensions as defined through the limits of
-the spatial locations to be plotted, and decides between the following two
-methods in order to avoid this issue:
-\itemize{
-\item{\strong{Method A.} First crop original image, then sample
-\code{max_sample} (default = 5e5) values to generate final image. Intended
-for smaller ROIs. Force usage of this method by setting
-\code{flex_resample = FALSE}}
-\item{\strong{Method B.} First oversample, then crop. Intended for larger
-ROIs. Base sample size is \code{max_sample}, which is then multiplied by a
-scale factor >1 that increases the smaller the ROI is and is defined by:
-original dimensions/crop dimensions where the larger ratio between x
-and y dims is chosen. Scale factor is capped by
-\code{max_resample_scale}}
-}
-Control points for this function are set by \code{max_crop} which decides
-the max ROI area after which switchover to method B happens in order to
-avoid laborious crops and \code{max_resample_scale} which determines the
-maximum scale factor for number of values to sample. Both values can be
-adjusted depending on system resources. Additionally, \code{flex_resample}
-determines if this switching behavior happens.
-When set to \code{FALSE}, only method A is used.
+Downsample terra-based images for plotting. Uses \code{\link[terra]{window}}
+to set a virtual reading window on the image before calling
+\code{\link[terra]{spatSample}}, so only the relevant spatial ROI is read
+from disk. This avoids materializing a crop to disk for large ROIs while
+still focusing sampling on the plot region.
 }
 \details{
 \strong{img_border}
-expand ext to use for plotting the image. This makes it so that the image
-is not cut off sharply at the edge of the plot extent. Needed since plots
-often define extent by centroids, and polygons may hang over the edge of the
-extent.
+Expands the window extent used for reading the image. This prevents the
+image from being cut off sharply at the plot boundary, since plot extents
+are typically defined by centroids and polygons may hang over the edge.
 }
 \examples{
 \dontrun{
@@ -92,6 +48,6 @@ img <- GiottoData::loadSubObjectMini("giottoLargeImage")
 }
 }
 \seealso{
-\code{\link[terra]{spatSample}}
+\code{\link[terra]{window}}, \code{\link[terra]{spatSample}}
 }
 \keyword{internal}

--- a/man/gg_annotation_raster.Rd
+++ b/man/gg_annotation_raster.Rd
@@ -41,8 +41,7 @@ of the plot requested.
 }
 \details{
 No ... params are implemented for \code{giottoImage}. \cr ... params for
-\code{giottoLargeImage} passes to automated resampling params see
-\code{?auto_image_resample} for details
+\code{giottoLargeImage} and \code{giottoAffineImage} pass to \code{?auto_image_resample}
 }
 \examples{
 gimg <- GiottoData::loadSubObjectMini("giottoLargeImage")


### PR DESCRIPTION
## bug fixes
- fix color gradient error when GiottoVisuals is not attached (loaded as dependency or via `::`): `giotto.color_cd_pal` and `giotto.color_cs_pal` options now have inline fallback defaults in `set_default_color_continuous()`
- `aes_string2()` fixed handling for column names that parse as numeric literals (e.g. "1", "2") that caused plotting to fail

## changes
- `auto_image_resample()` rewritten to use `terra::window()` instead of the two-method crop/oversample approach, simplifying the implementation and avoiding materialization of large crops to disk. `giottoAffineImage` is now also supported. Removed params: `flex_resample`, `max_crop`, `max_resample_scale` and their corresponding global options `giotto.plot_img_max_crop` and `giotto.plot_img_max_resample_scale`.
- feature value collection in `spatFeatPlot2D_single()`, `dimFeatPlot2D()`, `spatFeatPlot3D()`, `dimFeatPlot3D()`, `spatDimFeatPlot3D()`, and `violinPlot()` now uses `spatValues()`, replacing manual expression matrix extraction and transposition
- minimum GiottoClass version bumped to `>= 0.5.1`