### PR TITLE
Use canonical accessor argument names

### DIFF
--- a/R/vis_spatial_in_situ.R
+++ b/R/vis_spatial_in_situ.R
@@ -574,7 +574,7 @@ spatInSituPlotPoints <- function(
 
         polygon_dt <- getPolygonInfo(
             gobject = gobject,
-            polygon_name = polygon_feat_type
+            name = polygon_feat_type
         ) %>%
             data.table::as.data.table(geom = "XY")
 
@@ -869,7 +869,7 @@ spatInSituPlotHex <- function(gobject,
 
         polygon_dt <- getPolygonInfo(
             gobject = gobject,
-            polygon_name = polygon_feat_type
+            name = polygon_feat_type
         ) %>%
             data.table::as.data.table(geom = "XY")
 


### PR DESCRIPTION
> **Draft — blocked on giotto-suite/GiottoClass#381.** CI will fail until that merges. See Ordering.

giotto-suite/GiottoClass#381 aligns the accessor generics on one shared formal contract. `getPolygonInfo(polygon_name=)` becomes `getPolygonInfo(name=)`.

The old name keeps working through a deprecation alias, so this changes no behaviour — it stops our own code from emitting our own deprecation warnings.

2 call sites, both in `R/vis_spatial_in_situ.R`: `spatInSituPlotPoints()` and `spatInSituPlotHex()`.

Only the argument name changes; the value passed (`polygon_feat_type`, the enclosing functions' own parameter) is untouched, so the public signatures are unaffected.

## Ordering

**Merge after GiottoClass#381.** Before it, `getPolygonInfo` has no `...` to absorb `name=`, so these calls error with `unused argument` rather than warn. Verified against an installed GiottoClass.

## Test plan

- [x] `parse()` clean
- [ ] Not runnable until #381 lands and GiottoClass is reinstalled. Worth running at that point rather than assuming — it is 2 lines, but currently unexercised.