### PR TITLE
Merge dev into gsource

### DIFF
--- a/R/vis_spatial_in_situ.R
+++ b/R/vis_spatial_in_situ.R
@@ -574,7 +574,7 @@ spatInSituPlotPoints <- function(
 
         polygon_dt <- getPolygonInfo(
             gobject = gobject,
-            polygon_name = polygon_feat_type
+            name = polygon_feat_type
         ) %>%
             data.table::as.data.table(geom = "XY")
 
@@ -869,7 +869,7 @@ spatInSituPlotHex <- function(gobject,
 
         polygon_dt <- getPolygonInfo(
             gobject = gobject,
-            polygon_name = polygon_feat_type
+            name = polygon_feat_type
         ) %>%
             data.table::as.data.table(geom = "XY")
 


### PR DESCRIPTION
Brings the accessor-contract work (#132) onto the gsource line. Clean merge, no conflicts.

- `R/vis_spatial_in_situ.R` x2 - `getPolygonInfo(polygon_name=)` -> `name=`, in `spatInSituPlotPoints()` and `spatInSituPlotHex()`

Only the argument name changes; the value passed (`polygon_feat_type`) is untouched, so the public signatures are unaffected.

## Ordering

Depends on giotto-suite/GiottoClass#389 (dev -> gsource), which carries the rename. `getPolygonInfo` has no `...` to absorb `name=` before that lands, so these calls would error rather than warn.
